### PR TITLE
feat: aleo code import, compilation, and typegen

### DIFF
--- a/packages/cli/src/utils/graph.ts
+++ b/packages/cli/src/utils/graph.ts
@@ -1,52 +1,62 @@
+export interface NodeImport {
+  source: 'programs' | 'imports';
+  name: string;
+}
+
 export interface Node {
-    name: string,
-    inputs: Array<string>
+  name: string;
+  inputs: Array<NodeImport>;
 }
 
 export function sort(graph: Array<Node>) {
-    if (graph.length === 0) return;
+  if (graph.length === 0) return;
 
-    const kPushed = 0;
-    const kVisited = 1;
+  const kPushed = 0;
+  const kVisited = 1;
 
-    const visitedNode = new Array<number>(graph.length).fill(-1);
-    const sortedNode = [];
+  const visitedNode = new Array<number>(graph.length).fill(-1);
+  const sortedNode = [];
 
-    for (let i = 0; i < graph.length; ++i) {
-        if (visitedNode[i] != -1) continue;
+  for (let i = 0; i < graph.length; ++i) {
+    if (visitedNode[i] != -1) continue;
 
-        const stack = [i];
-        while (stack.length > 0) {
-            const nodeIndex = stack.at(-1);
+    const stack = [i];
+    while (stack.length > 0) {
+      const nodeIndex = stack.at(-1);
 
-            if (nodeIndex == undefined) break;
+      if (nodeIndex == undefined) break;
 
-            if (visitedNode[nodeIndex] == kPushed) {
-                stack.pop();
-                continue;
-            }
+      if (visitedNode[nodeIndex] == kPushed) {
+        stack.pop();
+        continue;
+      }
 
-            if (visitedNode[nodeIndex] == kVisited) {
-                stack.pop();
-                visitedNode[nodeIndex] = kPushed;
-                sortedNode.push(nodeIndex);
-                continue;
-            }
+      if (visitedNode[nodeIndex] == kVisited) {
+        stack.pop();
+        visitedNode[nodeIndex] = kPushed;
+        sortedNode.push(nodeIndex);
+        continue;
+      }
 
-            visitedNode[nodeIndex] = kVisited;
+      visitedNode[nodeIndex] = kVisited;
 
-            const nodePtr = graph[nodeIndex];
-            for (let edge of nodePtr.inputs) {
-                const edgeIndex = graph.findIndex(node => node.name === edge);
-                if (edgeIndex === -1) throw new Error(`import ${edge} for program ${nodePtr.name} is not in 'programs' directory`);
-                if (visitedNode[edgeIndex] != kVisited)
-                    stack.push(edgeIndex);
-            }
+      const nodePtr = graph[nodeIndex];
+      for (let edge of nodePtr.inputs) {
+        if (edge.name.endsWith('.aleo')) {
+          continue;
         }
-    }
 
-    let outputs = [];
-    for (let nodeIndex of sortedNode)
-        outputs.push(graph[nodeIndex]);
-    return outputs;
+        const edgeIndex = graph.findIndex((node) => node.name === edge.name);
+        if (edgeIndex === -1)
+          throw new Error(
+            `import ${edge.name} for program ${nodePtr.name} is not in 'programs' nor 'imports' directories`
+          );
+        if (visitedNode[edgeIndex] != kVisited) stack.push(edgeIndex);
+      }
+    }
+  }
+
+  let outputs = [];
+  for (let nodeIndex of sortedNode) outputs.push(graph[nodeIndex]);
+  return outputs;
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,6 +28,7 @@
     "@aleohq/sdk": "^0.6.9",
     "@doko-js/utils": "workspace:*",
     "aleo-ciphertext-decryptor": "^0.1.0",
+    "fs-extra": "^11.1.1",
     "js-beautify": "^1.14.11",
     "zod": "^3.22.4"
   }

--- a/packages/core/src/execution/execution.ts
+++ b/packages/core/src/execution/execution.ts
@@ -19,7 +19,7 @@ export function CreateExecutionContext(
     case ExecutionMode.LeoExecute:
       return new LeoExecuteContext(config);
     case ExecutionMode.SnarkExecute:
-      return new SnarkExecuteContext(config);
+      return new SnarkExecuteContext({ ...config });
   }
   throw new Error('Unsupported Execution Mode');
 }

--- a/packages/core/src/execution/execution.ts
+++ b/packages/core/src/execution/execution.ts
@@ -1,19 +1,25 @@
-import { isDefined } from "./execution-helper";
-import { LeoExecuteContext } from "./leo-execute";
-import { LeoRunContext } from "./leo-run";
-import { SnarkExecuteContext } from "./snark-execute";
-import { ContractConfig, ExecutionContext, ExecutionMode } from "./types";
+import { isDefined } from './execution-helper';
+import { LeoExecuteContext } from './leo-execute';
+import { LeoRunContext } from './leo-run';
+import { SnarkExecuteContext } from './snark-execute';
+import { ContractConfig, ExecutionContext, ExecutionMode } from './types';
 
-export function CreateExecutionContext(config: ContractConfig): ExecutionContext {
-    if (!isDefined(config.mode)) throw Error("Execution mode not selected in contract config");
-    switch (config.mode) {
-        case ExecutionMode.LeoRun:
-            return new LeoRunContext(config);
-        case ExecutionMode.LeoExecute:
-            return new LeoExecuteContext(config);
-        case ExecutionMode.SnarkExecute:
-            return new SnarkExecuteContext(config);
-
-    }
-    throw new Error('Unsupported Execution Mode');
+export function CreateExecutionContext(
+  config: ContractConfig
+): ExecutionContext {
+  if (!isDefined(config.mode))
+    throw Error('Execution mode not selected in contract config');
+  if (config.isImportedAleo && config.mode !== ExecutionMode.SnarkExecute)
+    throw Error(
+      "Execution of imported code is possible only with 'SnarkExecute' mode"
+    );
+  switch (config.mode) {
+    case ExecutionMode.LeoRun:
+      return new LeoRunContext(config);
+    case ExecutionMode.LeoExecute:
+      return new LeoExecuteContext(config);
+    case ExecutionMode.SnarkExecute:
+      return new SnarkExecuteContext(config);
+  }
+  throw new Error('Unsupported Execution Mode');
 }

--- a/packages/core/src/execution/snark-execute.ts
+++ b/packages/core/src/execution/snark-execute.ts
@@ -1,52 +1,65 @@
-import { ContractConfig, TransactionParams } from "./types";
-import { ExecutionContext, ExecutionOutput } from "./types";
-import { ExecutionOutputParser, SnarkStdoutResponseParser } from "./output-parser";
-import { formatArgs, execute, decryptOutput } from "./execution-helper";
-import { broadcastTransaction } from "./utils";
-import { TransactionModel } from "@aleohq/sdk";
-import { post } from "@/utils/httpRequests";
-import { SnarkExecuteResponse, TransactionResponse } from "@/leo-types/transaction/transaction-response";
+import { SnarkExecuteTransactionParams } from './types';
+import { ExecutionContext, ExecutionOutput } from './types';
+import {
+  ExecutionOutputParser,
+  SnarkStdoutResponseParser
+} from './output-parser';
+import { formatArgs, execute, decryptOutput } from './execution-helper';
+import { broadcastTransaction } from './utils';
+import { TransactionModel } from '@aleohq/sdk';
+import { post } from '@/utils/httpRequests';
+import {
+  SnarkExecuteResponse,
+  TransactionResponse
+} from '@/leo-types/transaction/transaction-response';
 
 export class SnarkExecuteContext implements ExecutionContext {
+  constructor(
+    public params: SnarkExecuteTransactionParams,
+    public parser: SnarkStdoutResponseParser = new SnarkStdoutResponseParser()
+  ) {}
 
-    constructor(public params: TransactionParams, public parser: SnarkStdoutResponseParser = new SnarkStdoutResponseParser()) {
+  private async broadcast(transaction: TransactionModel, endpoint: string) {
+    try {
+      return await post(
+        `${endpoint}/${this.params.networkName}/transaction/broadcast`,
+        {
+          body: JSON.stringify(transaction),
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        }
+      );
+    } catch (err) {
+      console.error(err);
+    }
+  }
 
+  async execute(
+    transitionName: string,
+    args: string[]
+  ): Promise<TransactionResponse> {
+    const nodeEndPoint = this.params.network?.endpoint;
+    if (!nodeEndPoint) {
+      throw new Error('networkName missing in contract config for deployment');
     }
 
-    private async broadcast(transaction: TransactionModel, endpoint: string) {
-        try {
-            return await post(`${endpoint}/${this.params.networkName}/transaction/broadcast`, {
-                body: JSON.stringify(transaction),
-                headers: {
-                    'Content-Type': 'application/json'
-                }
-            });
-        } catch (err) {
-            console.error(err);
-        }
-    }
+    const programName = this.params.appName + '.aleo';
+    const transitionArgs = formatArgs(args);
+    const cdCmd = this.params.isImportedAleo
+      ? ''
+      : `cd ${this.params.contractPath} && `;
+    // snarkos developer execute sample_program.aleo main  "1u32" "2u32" --private-key APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH --query "http://localhost:3030" --broadcast "http://localhost:3030/testnet3/transaction/broadcast"
+    // const cmd = `cd ${config.contractPath} && snarkos developer execute  ${config.appName}.aleo ${transition} ${stringedParams} --private-key ${config.privateKey} --query ${nodeEndPoint} --broadcast "${nodeEndPoint}/testnet3/transaction/broadcast"`;
+    // const cmd = `cd ${this.params.contractPath} && snarkos developer execute ${programName} ${transitionName} ${transitionArgs} --network ${this.params.networkMode} --private-key ${this.params.privateKey} --query ${nodeEndPoint} --dry-run`;
+    const cmd = `${cdCmd}snarkos developer execute ${programName} ${transitionName} ${transitionArgs} --private-key ${this.params.privateKey} --query ${nodeEndPoint} --dry-run`;
+    console.log(cmd);
 
-    async execute(transitionName: string, args: string[]): Promise<TransactionResponse> {
-        const nodeEndPoint = this.params.network?.endpoint;
-        if (!nodeEndPoint) {
-            throw new Error('networkName missing in contract config for deployment');
-        }
-
-        const programName = this.params.appName + '.aleo';
-        const transitionArgs = formatArgs(args);
-        // snarkos developer execute sample_program.aleo main  "1u32" "2u32" --private-key APrivateKey1zkp8CZNn3yeCseEtxuVPbDCwSyhGW6yZKUYKfgXmcpoGPWH --query "http://localhost:3030" --broadcast "http://localhost:3030/testnet3/transaction/broadcast"
-        // const cmd = `cd ${config.contractPath} && snarkos developer execute  ${config.appName}.aleo ${transition} ${stringedParams} --private-key ${config.privateKey} --query ${nodeEndPoint} --broadcast "${nodeEndPoint}/testnet3/transaction/broadcast"`;
-        // const cmd = `cd ${this.params.contractPath} && snarkos developer execute ${programName} ${transitionName} ${transitionArgs} --network ${this.params.networkMode} --private-key ${this.params.privateKey} --query ${nodeEndPoint} --dry-run`;
-        const cmd = `cd ${this.params.contractPath} && snarkos developer execute ${programName} ${transitionName} ${transitionArgs} --private-key ${this.params.privateKey} --query ${nodeEndPoint} --dry-run`;
-        console.log(cmd);
-
-        const { stdout } = await execute(cmd);
-        const { transaction } = this.parser.parse(stdout);
-        if (transaction) {
-            await this.broadcast(transaction, nodeEndPoint);
-            return new SnarkExecuteResponse(transaction, this.params, transitionName);
-        }
-        else
-            throw new Error('Invalid transaction object');
-    }
+    const { stdout } = await execute(cmd);
+    const { transaction } = this.parser.parse(stdout);
+    if (transaction) {
+      await this.broadcast(transaction, nodeEndPoint);
+      return new SnarkExecuteResponse(transaction, this.params, transitionName);
+    } else throw new Error('Invalid transaction object');
+  }
 }

--- a/packages/core/src/execution/types.ts
+++ b/packages/core/src/execution/types.ts
@@ -1,42 +1,48 @@
-import { TransactionModel } from "@aleohq/sdk";
+import { TransactionModel } from '@aleohq/sdk';
 import { tx } from '@/outputs';
-import { TransactionResponse } from "@/leo-types/transaction/transaction-response";
+import { TransactionResponse } from '@/leo-types/transaction/transaction-response';
 
 export enum ExecutionMode {
-    LeoRun,
-    LeoExecute,
-    SnarkExecute
-};
+  LeoRun,
+  LeoExecute,
+  SnarkExecute
+}
 
 interface NetworkConfig {
-    endpoint: string;
+  endpoint: string;
 }
 
 export interface ExecutionOutput {
-    data: any;
-    transaction?: TransactionModel & tx.Receipt;
+  data: any;
+  transaction?: TransactionModel & tx.Receipt;
 }
 
 export interface BaseConfig {
-    contractPath: string;
-    appName: string;
-    network: NetworkConfig;
-    networkName: string;
-    privateKey: string;
-    networkMode : number;
+  contractPath: string;
+  appName: string;
+  network: NetworkConfig;
+  networkName: string;
+  privateKey: string;
+  networkMode: number;
 }
 
 export interface ContractConfig extends BaseConfig {
-    fee?: string;
-    mode?: ExecutionMode;
-    priorityFee?: number;
+  fee?: string;
+  mode?: ExecutionMode;
+  priorityFee?: number;
+  isImportedAleo?: boolean;
 }
 
 export interface ExecutionContext {
-    execute(transitionName: string, params: string[]): Promise<TransactionResponse>;
+  execute(
+    transitionName: string,
+    params: string[]
+  ): Promise<TransactionResponse>;
 }
 
-export interface TransactionParams extends BaseConfig {
-}
+export interface TransactionParams extends BaseConfig {}
 
-export type LeoTransactionParams = Omit<TransactionParams, 'network' | 'networkName'>
+export type LeoTransactionParams = Omit<
+  TransactionParams,
+  'network' | 'networkName'
+>;

--- a/packages/core/src/execution/types.ts
+++ b/packages/core/src/execution/types.ts
@@ -46,3 +46,6 @@ export type LeoTransactionParams = Omit<
   TransactionParams,
   'network' | 'networkName'
 >;
+
+export type SnarkExecuteTransactionParams = TransactionParams &
+  Pick<ContractConfig, 'isImportedAleo'>;

--- a/packages/core/src/generator/generator.ts
+++ b/packages/core/src/generator/generator.ts
@@ -27,7 +27,8 @@ import {
   STRING_LEO,
   PROGRAM_DIRECTORY,
   LEO_FN_IMPORT,
-  JS_FN_IMPORT
+  JS_FN_IMPORT,
+  IMPORTS_PATH
 } from '@/generator/string-constants';
 
 import { toCamelCase } from '@doko-js/utils';
@@ -55,10 +56,17 @@ import {
 } from './generator-utils';
 import { OutputArg, TSReceiptTypeGenerator } from './ts-receipt-type-generator';
 
+type GeneratorParams = {
+  isImportedAleo?: boolean;
+};
+
 class Generator {
   private refl: AleoReflection;
-  constructor(aleoReflection: AleoReflection) {
+  private programParams?: GeneratorParams;
+
+  constructor(aleoReflection: AleoReflection, params?: GeneratorParams) {
     this.refl = aleoReflection;
+    this.programParams = params;
   }
 
   // Generate code for types file
@@ -149,9 +157,9 @@ class Generator {
       '\n' +
       (this.refl.customTypes.length > 0
         ? GenerateAsteriskTSImport(
-          `../types/${this.refl.programName}`,
-          'records'
-        ) + '\n'
+            `../types/${this.refl.programName}`,
+            'records'
+          ) + '\n'
         : '') +
       this.generateExternalTransitionsImport(
         this.refl.functions.flatMap((fn) => fn.calls)
@@ -395,10 +403,10 @@ class Generator {
       // for transition function parameter
       let fnName = isExternalRecord
         ? GenerateExternalRecordConversionStatement(
-          input.val,
-          argName,
-          STRING_LEO
-        )
+            input.val,
+            argName,
+            STRING_LEO
+          )
         : GenerateTypeConversionStatement(leoType, argName, STRING_LEO);
 
       // For custom type that produce object it must be converted to string
@@ -455,10 +463,10 @@ class Generator {
           : isRecordType
             ? `(this.config.mode===ExecutionMode.LeoRun) ? JSON.stringify(${input}) : ${input}`
             : GenerateTypeConversionStatement(
-              formattedOutput,
-              input,
-              STRING_JS
-            );
+                formattedOutput,
+                input,
+                STRING_JS
+              );
         fnGenerator.addStatement(`\tconst ${lhs} = ${rhs};\n`);
         if (this.refl.isCustomType(type)) {
           outUsedTypes.add(InferJSDataType(type));
@@ -554,8 +562,7 @@ class Generator {
   // Generate transition function body
   public generateContractClass() {
     const programName = this.refl.programName;
-    const classGenerator = new TSClassGenerator()
-      .extendsFrom('BaseContract')
+    const classGenerator = new TSClassGenerator().extendsFrom('BaseContract');
 
     const usedTypesSet = new Set<string>();
     classGenerator.addMethod(
@@ -563,9 +570,10 @@ class Generator {
         super({
           ...config,
           appName: '${programName}',
-          contractPath: '${PROGRAM_DIRECTORY}${programName}',
+          contractPath: '${this.programParams?.isImportedAleo ? IMPORTS_PATH : PROGRAM_DIRECTORY}${programName}',
           networkMode: config.networkName === 'testnet' ? 1 : 0, 
-          fee: '0.01'
+          fee: '0.01',
+          isImportedAleo: ${Boolean(this.programParams?.isImportedAleo)}
       });
   }\n`
     );

--- a/packages/core/src/generator/string-constants.ts
+++ b/packages/core/src/generator/string-constants.ts
@@ -32,3 +32,4 @@ export const STRING_LEO: string = 'leo';
 
 export const GENERATE_FILE_OUT_DIR = 'artifacts/js/';
 export const PROGRAM_DIRECTORY = 'artifacts/leo/';
+export const IMPORTS_PATH = 'imports/';

--- a/packages/core/src/utils/aleo-utils.ts
+++ b/packages/core/src/utils/aleo-utils.ts
@@ -134,6 +134,17 @@ function trimAleoPostfix(text: string) {
   return text;
 }
 
+function extractProgramName(aleoCode: string): string {
+  const regex = /program\s+([\w.]+);/g;
+  let match;
+
+  if ((match = regex.exec(aleoCode)) !== null) {
+    return match[1];
+  }
+
+  throw new Error('Aleo code malformed: program name not found');
+}
+
 export {
   TokenInfo,
   TokenType,
@@ -153,5 +164,6 @@ export {
   trimAleoPostfix,
   ExternalRecord,
   KEYWORDS,
-  CALL_OPERATOR
+  CALL_OPERATOR,
+  extractProgramName
 };

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,2 +1,2 @@
-export * from "./aleo-utils"
-export * from "./js-formatter"
+export * from './aleo-utils';
+export * from './js-formatter';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       aleo-ciphertext-decryptor:
         specifier: ^0.1.0
         version: 0.1.0
+      fs-extra:
+        specifier: ^11.1.1
+        version: 11.2.0
       js-beautify:
         specifier: ^1.14.11
         version: 1.14.11
@@ -114,20 +117,22 @@ importers:
         specifier: ^3.22.4
         version: 3.22.4
 
-  packages/test:
+  packages/utils: {}
+
+  test:
     dependencies:
       '@aleohq/sdk':
         specifier: ^0.6.9
         version: 0.6.9
       '@doko-js/cli':
         specifier: workspace:*
-        version: link:../cli
+        version: link:../packages/cli
       '@doko-js/core':
         specifier: workspace:*
-        version: link:../core
+        version: link:../packages/core
       '@doko-js/utils':
         specifier: workspace:*
-        version: link:../utils
+        version: link:../packages/utils
       aleo-program-to-address:
         specifier: ^0.1.0
         version: 0.1.0
@@ -153,8 +158,6 @@ importers:
       ts-jest:
         specifier: ^29.1.2
         version: 29.1.2(@babel/core@7.24.4)(babel-jest@29.7.0)(jest@29.7.0)(typescript@5.3.3)
-
-  packages/utils: {}
 
 packages:
 


### PR DESCRIPTION
# Feature description

Ability to use the Aleo programs in the whole development flow: coding, testing, deploying

## Motivation

There are many cases when the developer needs to use Aleo programs that do not have Leo sources. The most common case is the **credits.aleo**. The developer has to develop its own "interface" Leo program for such dependencies that contains all used methods, mappings, and records. 
The ability to use Aleo code directly will streamline the development process and prevent the risk of mistakes in interface contract signatures that Leo and Snarkos tools do not display.

Another case is a near-release of Leo v2 that breaks the interoperability with previously developed code. In order to integrate v1 Leo code with freshly developed v2 programs we need to compile it to Aleo code and import it directly. 
So, this feature will provide a smoother migration process for projects with large codebase.

# Usage

In order to import the Aleo program you have to add the __imports__ directory to your project root. You need to add the Aleo code there as <your_program_name>.aleo file. Any dependencies that have your Aleo program should be added to the __imports__ dir as well. The Aleo program must depend only on other Aleo programs.

## Example

You have to integrate some __prog_a__ to your Leo code.

So you have to create the file __./imports/prog_a.aleo__ and put its source code there
```aleo
import credits.aleo;
program prog_a.aleo;


function withdraw_credits_public:
    input r0 as u64.private;
    call credits.aleo/transfer_public self.caller r0 into r1;
    cast r0 into r2 as u128;
    async withdraw_credits_public r1 r2 self.caller into r3;
    output r3 as prog_a.aleo/withdraw_credits_public.future;

finalize withdraw_credits_public:
    input r0 as credits.aleo/transfer_public.future;
    input r1 as u128.public;
    input r2 as address.public;
    await r0;
```

It seems your program depends on __credits.aleo__ program. So you have to create __./imports/credits.aleo__ file and put [original credits.aleo code](https://github.com/AleoNet/snarkVM/blob/mainnet-staging/synthesizer/program/src/resources/credits.aleo) there.

Now you can call `dokojs compile` as usual. The CLI will add the aleo sources to build and generate typesafe classes and methods for it. So you could deploy and call this contracts as regular Leo programs in your test cases and scripts