### PR TITLE
fix: Leo v2 compatibility network flag

### DIFF
--- a/packages/cli/src/scripts/compile.ts
+++ b/packages/cli/src/scripts/compile.ts
@@ -238,7 +238,9 @@ async function buildProgram(programName: string) {
     }
   }
 
-  const leoBuildCommand = `cd "${programDir}" && leo build --home ${leoHomeDir}`;
+  const networkFlag = defaultNetwork ? `--network ${defaultNetwork}` : '';
+
+  const leoBuildCommand = `cd "${programDir}" && leo build --home ${leoHomeDir} ${networkFlag}`;
   const shellCommand = new Shell(leoBuildCommand);
   const res = await shellCommand.asyncExec();
 


### PR DESCRIPTION
## Motivation
With Leo v2 release rised the compatibility issue for imported aleo code.
LeoV2 takes the network for dependencies fetch from environment and assumes that all dependencies should be taken from there. Also it could be defined with cli flag `--network`

LeoV1 takes the network and endpoint from the each particular dependency configuration. 

This behavior change breaks network dependencies retrieving process and aleo sources import.

## Solution

We need to update the leo compile command for Leo V2 cli for compilation process stability. The dokojs will take default network from its manifest and add it as flag to the leo build command