### PR TITLE
Fix token test

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,6 @@ import { decrypttoken } from '../artifacts/js/leo2js/token';
 import { PrivateKey } from '@provablehq/sdk';
 
 const TIMEOUT = 200_000;
-const amount = BigInt(2);
 
 // Available modes are evaluate | execute (Check README.md for further description)
 const mode = ExecutionMode.SnarkExecute;
@@ -309,7 +308,7 @@ describe('deploy test', () => {
       const tx = await contract.transfer_private(
         decryptedRecord,
         receiptAddress,
-        amount
+        amount2
       );
       const [record1, record2] = await tx.wait();
       const decryptedRecord2 = decrypttoken(record1, account);

--- a/packages/cli/template/README.md
+++ b/packages/cli/template/README.md
@@ -246,7 +246,6 @@ import { decrypttoken } from '../artifacts/js/leo2js/token';
 import { PrivateKey } from '@provablehq/sdk';
 
 const TIMEOUT = 200_000;
-const amount = BigInt(2);
 
 // Available modes are evaluate | execute (Check README.md for further description)
 const mode = ExecutionMode.SnarkExecute;
@@ -309,7 +308,7 @@ describe('deploy test', () => {
       const tx = await contract.transfer_private(
         decryptedRecord,
         receiptAddress,
-        amount
+        amount2
       );
       const [record1, record2] = await tx.wait();
       const decryptedRecord2 = decrypttoken(record1, account);

--- a/packages/cli/template/test/token.test.ts
+++ b/packages/cli/template/test/token.test.ts
@@ -4,7 +4,6 @@ import { decrypttoken } from '../artifacts/js/leo2js/token';
 import { PrivateKey } from '@provablehq/sdk';
 
 const TIMEOUT = 200_000;
-const amount = BigInt(2);
 
 // Available modes are evaluate | execute (Check README.md for further description)
 const mode = ExecutionMode.SnarkExecute;
@@ -67,7 +66,7 @@ describe('deploy test', () => {
       const tx = await contract.transfer_private(
         decryptedRecord,
         receiptAddress,
-        amount
+        amount2
       );
       const [record1, record2] = await tx.wait();
       const decryptedRecord2 = decrypttoken(record1, account);


### PR DESCRIPTION
There is a bug in the token test. 
In the `private transfer to user` test, the test account transfer 2 (`amount`), but there is an assertion that the record value is 100000000, (`amount2`), less. I fixed it and updated the readme with the fix.