### PR TITLE
Fix array compilation

### DIFF
--- a/packages/core/src/generator/generator-utils.ts
+++ b/packages/core/src/generator/generator-utils.ts
@@ -82,7 +82,13 @@ export function GenerateTypeConversionStatement(
     fn = `${namespace}.${fn}`;
 
     if (conversionTo === 'leo') {
-      if (qualifier) fn = `${namespace}.${qualifier}Field(${fn})`;
+      if (qualifier) {
+        if(isArray) {
+          fn = `${namespace}.${conversionFnName}(${fn}, ${namespace}.${qualifier}Field)`;
+        } else {
+          fn = `${namespace}.${qualifier}Field(${fn})`;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
There is a bug with array compilation in the js2leo files.

e.g, If there is an array of private fields property inside a record, the array will be compiled in the js2leo files as:

`array_property:  js2leo.privateField(js2leo.array(array_property, js2leo.field))`

The `privateField` function expects to get a string, so when you try to run a test with the program that has this record, you will immediately get this error: Type 'string' is not assignable to type 'string[]'.

I fixed this issue, and after this PR, the array will be compiled to:

`array_property:  js2leo.array(js2leo.array(array_property, js2leo.field), js2leo.privateField)`

Please review and approve this PR ASAP. Any project that uses records with array properties can't use doko-js because of that.