### PR TITLE
Update @provablehq/sdk to 0.8.8v

### DIFF
--- a/packages/cli/template/package.json
+++ b/packages/cli/template/package.json
@@ -18,7 +18,7 @@
     "ts-jest": "29.1.1"
   },
   "dependencies": {
-    "@provablehq/sdk": "0.6.9",
+    "@provablehq/sdk": "0.8.8",
     "dotenv": "^16.3.1",
     "zod": "^3.22.4"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/venture23-aleo/doko-js#readme",
   "dependencies": {
-    "@provablehq/sdk": "0.6.9",
+    "@provablehq/sdk": "0.8.8",
     "@doko-js/utils": "workspace:*",
     "@doko-js/wasm": "workspace:*",
     "fs-extra": "^11.1.1",

--- a/packages/core/src/execution/execution-helper.ts
+++ b/packages/core/src/execution/execution-helper.ts
@@ -1,5 +1,5 @@
 // @TODO replace this with shell
-import { Output, TransactionModel } from '@provablehq/sdk';
+import { Transaction } from '@provablehq/sdk';
 import { Decrypter } from '@doko-js/wasm';
 import { exec } from 'child_process';
 import { promisify } from 'util';
@@ -20,7 +20,7 @@ export function isDefined(v: any) {
 }
 
 export function decryptOutput(
-  transaction: TransactionModel,
+  transaction: Transaction,
   transitionName: string,
   programName: string,
   privateKey: string,

--- a/packages/core/src/execution/snark-execute.ts
+++ b/packages/core/src/execution/snark-execute.ts
@@ -1,4 +1,4 @@
-import { TransactionModel } from '@provablehq/sdk';
+import { Transaction } from '@provablehq/sdk';
 import { DokoJSError, DokoJSLogger, ERRORS } from '@doko-js/utils';
 
 import { SnarkExecuteTransactionParams, ExecutionContext } from './types';
@@ -16,7 +16,7 @@ export class SnarkExecuteContext implements ExecutionContext {
     public parser: SnarkStdoutResponseParser = new SnarkStdoutResponseParser()
   ) {}
   /*
-  private async broadcast(transaction: TransactionModel, endpoint: string) {
+  private async broadcast(transaction: Transaction, endpoint: string) {
     try {
       return await post(
         `${endpoint}/${this.params.networkName}/transaction/broadcast`,

--- a/packages/core/src/execution/types.ts
+++ b/packages/core/src/execution/types.ts
@@ -1,4 +1,4 @@
-import { TransactionModel } from '@provablehq/sdk';
+import { Transaction } from '@provablehq/sdk';
 import { tx } from '@/outputs';
 import { TransactionResponse } from '@/leo-types/transaction/transaction-response';
 
@@ -15,7 +15,7 @@ interface NetworkConfig {
 
 export interface ExecutionOutput {
   data: any;
-  transaction?: (TransactionModel & tx.Receipt) | string;
+  transaction?: (Transaction & tx.Receipt) | string;
 }
 
 export interface BaseConfig {

--- a/packages/core/src/execution/utils.ts
+++ b/packages/core/src/execution/utils.ts
@@ -1,6 +1,6 @@
 import { get, post } from '@/utils/httpRequests';
 import { ContractConfig } from './types';
-import { TransactionModel } from '@provablehq/sdk';
+import { Transaction } from '@provablehq/sdk';
 import { execute } from './execution-helper';
 import {
   SnarkDeployResponse,
@@ -69,7 +69,7 @@ export const checkDeployment = async (endpoint: string): Promise<boolean> => {
 };
 
 export const broadcastTransaction = async (
-  transaction: TransactionModel,
+  transaction: Transaction,
   endpoint: string,
   networkName: string
 ) => {
@@ -142,12 +142,12 @@ async function deployAleo(
   // const { stdout } = await execute(cmd);
   // const result = new SnarkStdoutResponseParser().parse(stdout);
   // await broadcastTransaction(
-  //   result.transaction as TransactionModel,
+  //   result.transaction as Transaction,
   //   nodeEndPoint,
   //   config.networkName!
   // );
   // return new SnarkDeployResponse(
-  //   result.transaction as TransactionModel,
+  //   result.transaction as Transaction,
   //   config
   // );
   const cmd = leoDeployCommand(
@@ -227,7 +227,7 @@ export const snarkDeploy = async ({
   );
   // // @TODO check it later
   // await broadcastTransaction(
-  //   result as TransactionModel,
+  //   result as Transaction,
   //   nodeEndPoint,
   //   config.networkName!
   // );
@@ -248,7 +248,7 @@ export const leoDeployCommand = (
 export const transactionHashToTransactionResponseObject = (
   transactionHash: string,
   type: 'deploy' | 'execute'
-): TransactionModel | null => {
+): Transaction | null => {
   const transaction = { id: transactionHash, type, execution: { edition: 1 } };
   return transaction;
 };
@@ -257,7 +257,7 @@ export const validateBroadcast = async (
   transactionId: string,
   nodeEndpoint: string,
   networkName: string
-): Promise<TransactionModel | null> => {
+): Promise<Transaction | null> => {
   const pollUrl = `${nodeEndpoint}/${networkName}/transaction/${transactionId}`;
   const timeoutMs = 60_000;
   const pollInterval = 1000; // 1 second
@@ -269,7 +269,7 @@ export const validateBroadcast = async (
   while (Date.now() - startTime < timeoutMs) {
     try {
       const response = await get(pollUrl);
-      const data = (await response.json()) as TransactionModel & {
+      const data = (await response.json()) as Transaction & {
         deployment: any;
       };
       if (!data.execution && !data.deployment) {
@@ -288,7 +288,7 @@ export const validateBroadcast = async (
 };
 
 export const waitTransaction = async (
-  transaction: TransactionModel,
+  transaction: Transaction,
   endpoint: string,
   networkName: string
 ) => {

--- a/packages/core/src/generator/generator.ts
+++ b/packages/core/src/generator/generator.ts
@@ -485,7 +485,7 @@ class Generator {
       (returnValues) => returnValues.converterFunction
     );
 
-    const returnType = `Promise<TransactionResponse<TransactionModel & receipt.${GetProgramTransitionsTypeName(this.refl.programName, func.name)}, [${types.join(',')}]>>`;
+    const returnType = `Promise<TransactionResponse<Transaction & receipt.${GetProgramTransitionsTypeName(this.refl.programName, func.name)}, [${types.join(',')}]>>`;
     if (converterFns.length > 0) {
       fnGenerator.addStatement(
         `result.set_converter_fn([${converterFns.join(', ')}]);\n`
@@ -629,7 +629,7 @@ class Generator {
         '@doko-js/core'
       ),
       GenerateTSImport(['BaseContract'], '../../contract/base-contract'),
-      GenerateTSImport(['TransactionModel'], '@provablehq/sdk'),
+      GenerateTSImport(['Transaction'], '@provablehq/sdk'),
       GenerateAsteriskTSImport(`./transitions/${programName}`, 'receipt'),
       '\n\n'
     );

--- a/packages/core/src/leo-types/transaction/transaction-response.ts
+++ b/packages/core/src/leo-types/transaction/transaction-response.ts
@@ -4,14 +4,14 @@ import { TransactionParams } from '@/execution';
 import { get } from '@/utils/httpRequests';
 import { DokoJSError, ERRORS } from '@doko-js/utils';
 import { Optional } from '@/execution';
-import { TransactionModel } from '@provablehq/sdk';
+import { Transaction } from '@provablehq/sdk';
 
 type Tuple = Optional<Array<unknown>>;
 type ConverterFn = (val: any, rest?: any) => any;
 type ConverterFnDefinition = [ConverterFn, ...string[]];
 
 export abstract class TransactionResponse<
-  TransactionDefinition extends TransactionModel = TransactionModel,
+  TransactionDefinition extends Transaction = Transaction,
   Result = Tuple
 > {
   // Outputs for the transition for which this object is returned
@@ -63,7 +63,7 @@ export abstract class TransactionResponse<
 }
 
 export class LeoRunResponse<
-  TransactionDefinition extends TransactionModel,
+  TransactionDefinition extends Transaction,
   Result extends Tuple = Tuple
 > extends TransactionResponse<TransactionDefinition, Result> {
   constructor(outputs: Record<string, unknown>[]) {
@@ -77,7 +77,7 @@ export class LeoRunResponse<
 }
 
 export class LeoExecuteResponse<
-  TransactionDefinition extends TransactionModel = TransactionModel,
+  TransactionDefinition extends Transaction = Transaction,
   Result extends Tuple = Tuple
 > extends TransactionResponse<TransactionDefinition, Result> {
   transaction: TransactionDefinition;
@@ -114,7 +114,7 @@ export class LeoExecuteResponse<
 }
 
 export class SnarkExecuteResponse<
-  TransactionDefinition extends TransactionModel = TransactionModel,
+  TransactionDefinition extends Transaction = Transaction,
   Result extends Tuple = Tuple
 > extends TransactionResponse<TransactionDefinition, Result> {
   protected transaction: TransactionDefinition | null;
@@ -178,7 +178,7 @@ export class SnarkExecuteResponse<
 }
 
 export class SnarkDeployResponse<
-  TransactionDefinition extends TransactionModel = TransactionModel,
+  TransactionDefinition extends Transaction = Transaction,
   Result extends Tuple = Tuple
 > extends SnarkExecuteResponse<TransactionDefinition, Result> {
   constructor(transactionId: string, transactionParams: TransactionParams) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,8 +108,8 @@ importers:
         specifier: workspace:*
         version: link:../wasm
       '@provablehq/sdk':
-        specifier: 0.6.9
-        version: 0.6.9
+        specifier: 0.8.8
+        version: 0.8.8
       fs-extra:
         specifier: ^11.1.1
         version: 11.2.0
@@ -239,8 +239,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/utils
       '@provablehq/sdk':
-        specifier: 0.6.9
-        version: 0.6.9
+        specifier: 0.8.8
+        version: 0.8.8
       aleo-program-to-address:
         specifier: ^0.1.0
         version: 0.1.0
@@ -1289,8 +1289,14 @@ packages:
   '@provablehq/sdk@0.6.9':
     resolution: {integrity: sha512-Hf3zTBUzVJyZj1l6BDC3KhMVsHFm7M2v8nnrYyL3npiENvY4AtMZUxHWdfEEyRlU/RK44aTE09cYyjs4DM89sA==}
 
+  '@provablehq/sdk@0.8.8':
+    resolution: {integrity: sha512-OuogQY7fPixxUxbI6n+GIEH9Sx5RtVuglRrFQnj3C8UNrgUQGMToR20glxabn6HMaDgTl+2zVTmUG8I15dHRaA==}
+
   '@provablehq/wasm@0.6.13':
     resolution: {integrity: sha512-M7H0kM240xtYryENXVbRUpW07+LOsnpt+s+X7Q7i/4lbEMWDB9lInLs987AF3EsRdRwx+eiz2ul9jraBvZ0jcg==}
+
+  '@provablehq/wasm@0.8.8':
+    resolution: {integrity: sha512-EOB36wv9bAb8ISDje8ambIyixtVgkgCycUg76vlx6O9OsCSpe+4TW6kZuqc5F398GRFeo46F0Ll4NtxiYELfpw==}
 
   '@rc-component/async-validator@5.0.4':
     resolution: {integrity: sha512-qgGdcVIF604M9EqjNF0hbUTz42bz/RDtxWdWuU5EQe3hi7M8ob54B6B35rOsvX5eSvIHIzT9iH1R3n+hk3CGfg==}
@@ -2151,6 +2157,9 @@ packages:
   comlink@4.4.1:
     resolution: {integrity: sha512-+1dlx0aY5Jo1vHy/tSsIGpSkN4tS9rZSW8FIhG0JH/crs9wwweswIo/POr451r7bZww3hFbPAKnTpimzL/mm4Q==}
 
+  comlink@4.4.2:
+    resolution: {integrity: sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==}
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
@@ -2223,6 +2232,9 @@ packages:
 
   core-js-compat@3.38.1:
     resolution: {integrity: sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==}
+
+  core-js@3.41.0:
+    resolution: {integrity: sha512-SJ4/EHwS36QMJd6h/Rg+GyR4A5xE0FSI3eZ+iBVpfqf1x0eTSg1smWLHrA+2jQThZSh97fmSgFSU8B61nxosxA==}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -3613,6 +3625,11 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
 
+  mime@4.0.7:
+    resolution: {integrity: sha512-2OfDPL+e03E0LrXaGYOtTFIYhiuzep94NSsuhrNULq+stylcJedcHdzHtz0atMUuGwJfFYs0YL5xeC/Ca2x0eQ==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -4978,6 +4995,10 @@ packages:
   write-file-atomic@4.0.2:
     resolution: {integrity: sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
+  xmlhttprequest-ssl@3.1.0:
+    resolution: {integrity: sha512-UsofFE/khRRAcM9c3FGDEUSwupaQQC3Kme1brtz+B3N+RZHXGbD6AG6QzgWcunHzszqtOSMiZoPNrmHEBB2DjA==}
+    engines: {node: '>=12.0.0'}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -6384,7 +6405,18 @@ snapshots:
       mime: 3.0.0
       sync-request: 6.1.0
 
+  '@provablehq/sdk@0.8.8':
+    dependencies:
+      '@provablehq/wasm': 0.8.8
+      comlink: 4.4.2
+      core-js: 3.41.0
+      mime: 4.0.7
+      sync-request: 6.1.0
+      xmlhttprequest-ssl: 3.1.0
+
   '@provablehq/wasm@0.6.13': {}
+
+  '@provablehq/wasm@0.8.8': {}
 
   '@rc-component/async-validator@5.0.4':
     dependencies:
@@ -7385,6 +7417,8 @@ snapshots:
 
   comlink@4.4.1: {}
 
+  comlink@4.4.2: {}
+
   comma-separated-tokens@2.0.3: {}
 
   commander@10.0.1: {}
@@ -7460,6 +7494,8 @@ snapshots:
   core-js-compat@3.38.1:
     dependencies:
       browserslist: 4.24.0
+
+  core-js@3.41.0: {}
 
   core-util-is@1.0.3: {}
 
@@ -9398,6 +9434,8 @@ snapshots:
 
   mime@3.0.0: {}
 
+  mime@4.0.7: {}
+
   mimic-fn@2.1.0: {}
 
   minimalistic-assert@1.0.1: {}
@@ -10975,6 +11013,8 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 3.0.7
+
+  xmlhttprequest-ssl@3.1.0: {}
 
   xtend@4.0.2: {}
 

--- a/test/package.json
+++ b/test/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@doko-js/cli": "workspace:*",
     "@doko-js/core": "workspace:*",
-    "@provablehq/sdk": "0.6.9",
+    "@provablehq/sdk": "0.8.8",
     "@doko-js/utils": "workspace:*",
     "aleo-program-to-address": "^0.1.0",
     "dotenv": "^16.4.5",


### PR DESCRIPTION
If a project uses Dokojs and a new version of `@provablehw/sdk`, it will get an error because there are breaking changes between 0.6.9v and 0.8.8v